### PR TITLE
use ensure_packages() to install jq

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -16,9 +16,7 @@ class lldpd::service {
   }
   if $lldpd::manage_facts {
     if $lldpd::manage_jq {
-      package{'jq':
-        ensure => 'present',
-      }
+      ensure_packages(['jq'], { 'ensure' => 'present'})
     }
     file{'/usr/local/bin/lldp2facts':
       ensure => 'file',


### PR DESCRIPTION
jq is pretty common. It is possible that other modules as well define
it. To workaround this issue, we use ensure_packages() instead of the
package resource.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
