### PR TITLE
Add VirtuozzoLinux 6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ This module supports the installation on:
 * Debian 9
 * Ubuntu 16.04
 * Ubuntu 18.04
-* Virtuozzo Linux 6
+* VirtuozzoLinux 6
+* VirtuozzoLinux 7
 * Parallels Cloud Server Bare Metal 5
 * FreeBSD 11
-* VirtuozzoLinux 7
 
 The fact is present on all Operating Systems except for FreeBSD. Docker
 acceptance tests work for CentOS 6 and 7. Vagrant acceptance tests work for

--- a/data/VirtuozzoLinux-6.yaml
+++ b/data/VirtuozzoLinux-6.yaml
@@ -1,0 +1,3 @@
+---
+lldpd::repourl: 'CentOS_CentOS-6'
+lldpd::manage_jq: true

--- a/metadata.json
+++ b/metadata.json
@@ -70,6 +70,7 @@
     {
       "operatingsystem": "VirtuozzoLinux",
       "operatingsystemrelease": [
+        "6",
         "7"
       ]
     }


### PR DESCRIPTION
`facter` 3.14 adds support for `os.name` *VirtuozzoLinux* (https://puppet.com/docs/puppet/latest/release_notes_facter.html). This means `os.name` won't resolve to *RedHat* anymore.