### PR TITLE
Binaries now exist for 20.04 so use the repo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,10 @@ matrix:
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
+    env: BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=ubuntu2004-64 CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
     env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=centos6-64 CHECK=beaker
     services: docker
   - rvm: 2.5.3

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ This module supports the installation on:
 * Debian 10
 * Ubuntu 16.04
 * Ubuntu 18.04
+* Ubuntu 20.04
 * VirtuozzoLinux 6
 * VirtuozzoLinux 7
 * Parallels Cloud Server Bare Metal 5

--- a/data/Ubuntu-20.04.yaml
+++ b/data/Ubuntu-20.04.yaml
@@ -1,0 +1,2 @@
+---
+lldpd::repourl: 'xUbuntu_20.04'

--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "16.04",
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     },
     {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
I checked and upstream binaries exist for 18.04 and at my request they now exist for 20.04, so both versions use the upstream.

I tested this on 20.04 by pointing to my repo in my Puppetfile and it behaves as expected.  I did not test on 18.04

#### This Pull Request (PR) fixes the following issues
n/a
