### PR TITLE
CentOS 6: Fix mirror URL

### DIFF
--- a/data/CentOS-6.yaml
+++ b/data/CentOS-6.yaml
@@ -1,2 +1,0 @@
----
-lldpd::repourl: 'CentOS_CentOS-6'

--- a/data/CentOS-7.yaml
+++ b/data/CentOS-7.yaml
@@ -1,2 +1,0 @@
----
-lldpd::repourl: 'CentOS_7'

--- a/data/RedHat-6.yaml
+++ b/data/RedHat-6.yaml
@@ -1,2 +1,2 @@
 ---
-lldpd::repourl: 'CentOS_CentOS-6'
+lldpd::repourl: 'CentOS-6'

--- a/data/VirtuozzoLinux-6.yaml
+++ b/data/VirtuozzoLinux-6.yaml
@@ -1,3 +1,2 @@
 ---
-lldpd::repourl: 'CentOS_CentOS-6'
 lldpd::manage_jq: true

--- a/data/VirtuozzoLinux-7.yaml
+++ b/data/VirtuozzoLinux-7.yaml
@@ -1,3 +1,2 @@
 ---
-lldpd::repourl: 'CentOS_7'
 lldpd::manage_jq: true

--- a/data/VirtuozzoLinux.yaml
+++ b/data/VirtuozzoLinux.yaml
@@ -1,3 +1,2 @@
 ---
-lldpd::manage_jq: false
 lldpd::repourl: 'CentOS_%{facts.os.release.major}'


### PR DESCRIPTION
the upstream URL changed in https://github.com/lldpd/lldpd/issues/415