### PR TITLE
Add RHEL 8 repo override

### DIFF
--- a/data/RedHat-8.yaml
+++ b/data/RedHat-8.yaml
@@ -1,0 +1,2 @@
+---
+lldpd::repourl: 'CentOS_8'

--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,8 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7", "8"
+        "7",
+        "8"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -29,13 +29,13 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "7", "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7", "8"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,8 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7", "8"
+        "7", 
+        "8"
       ]
     },
     {


### PR DESCRIPTION
Add RedHat 8 support. RHEL8 does include `lldpd`, but it is an older version. OpenSuse doesn't build for RHEL8, but the CentOS 8 package works.