### PR TITLE
Apt: Use gpg repo key only for lldpd repository

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,12 +40,10 @@ class lldpd (
           mode   => '0644',
         }
         # purge old key files that we installed in previous releases
-        $old_keys = ['/etc/apt/trusted.gpg.d/home_vbernat.gpg', '/etc/apt/trusted.gpg.d/home_vbernat.gpg~',]
-        $old_keys.each |Stdlib::Absolutepath $key| {
-          file { $key:
-            ensure => 'absent',
-          }
+        file { ['/etc/apt/trusted.gpg.d/home_vbernat.gpg', '/etc/apt/trusted.gpg.d/home_vbernat.gpg~']:
+          ensure => absent,
         }
+
         # previously managed by apt::key, we need to purge it from the global keyring in /etc/apt/trusted.gpg
         include apt # required so apt::key can access variables from init.pp
         apt::key { 'EF795E4D26E48F1D7661267B431C37A97C3E114B':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,7 +32,8 @@ class lldpd (
           fail('you must specify a `$gpgkeyfingerprint` when using `$manage_repo` on debian')
         }
         # place the key in the keyrings directory where apt won't search for keys for all repos
-        file { '/usr/share/keyrings/lldpd.gpg':
+        # ascii encoded files need to end with *.asc, binary files with .gpg...
+        file { '/usr/share/keyrings/lldpd.asc':
           source => "https://download.opensuse.org/repositories/home:/vbernat/${repourl}/Release.key",
           owner  => 'root',
           group  => 'root',
@@ -51,11 +52,11 @@ class lldpd (
           ensure => 'absent',
         }
         apt::source { 'lldpd':
-          location => "http://download.opensuse.org/repositories/home:/vbernat/${repourl}",
+          location => "https://download.opensuse.org/repositories/home:/vbernat/${repourl}",
           release  => ' ',
           repos    => '/',
-          keyring  => '/usr/share/keyrings/lldpd.gpg',
-          require  => File['/usr/share/keyrings/lldpd.gpg'],
+          keyring  => '/usr/share/keyrings/lldpd.asc',
+          require  => File['/usr/share/keyrings/lldpd.asc'],
         }
       }
       default: {

--- a/spec/classes/lldpd_spec.rb
+++ b/spec/classes/lldpd_spec.rb
@@ -6,7 +6,7 @@ describe 'lldpd' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let :facts do
-        facts.merge({systemd: true})
+        facts.merge({ systemd: true })
       end
 
       context 'with all defaults' do
@@ -28,7 +28,7 @@ describe 'lldpd' do
         if facts[:os]['family'] == 'Debian' && facts[:os]['release']['full'] != '18.04'
           it { is_expected.to contain_apt__source('lldpd') }
           it { is_expected.to contain_apt__key('EF795E4D26E48F1D7661267B431C37A97C3E114B').with_ensure('absent') }
-          it { is_expected.to contain_file('/usr/share/keyrings/lldpd.gpg') }
+          it { is_expected.to contain_file('/usr/share/keyrings/lldpd.asc') }
           it { is_expected.to contain_file('/etc/apt/trusted.gpg.d/home_vbernat.gpg').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/apt/trusted.gpg.d/home_vbernat.gpg~').with_ensure('absent') }
         else


### PR DESCRIPTION
This is based on the apt tips from https://blog.cloudflare.com/dont-use-apt-key/

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
