### PR TITLE
Drop legacy gpgkeyfingerprint parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -30,8 +30,8 @@ The following parameters are available in the `lldpd` class:
 * [`manage_service`](#manage_service)
 * [`manage_repo`](#manage_repo)
 * [`repourl`](#repourl)
-* [`gpgkeyfingerprint`](#gpgkeyfingerprint)
 * [`apt_key_hash`](#apt_key_hash)
+* [`gpgkeyfingerprint`](#gpgkeyfingerprint)
 
 ##### <a name="ensure"></a>`ensure`
 
@@ -65,14 +65,6 @@ String that completes the url for the upstream repository
 
 Default value: ``undef``
 
-##### <a name="gpgkeyfingerprint"></a>`gpgkeyfingerprint`
-
-Data type: `Optional[String[40]]`
-
-String with the ID from the gpg key that signed the packages
-
-Default value: ``undef``
-
 ##### <a name="apt_key_hash"></a>`apt_key_hash`
 
 Data type: `String[1]`
@@ -80,4 +72,12 @@ Data type: `String[1]`
 the sha256 hashsum for the GPG key file that was used to sign the packages
 
 Default value: `'2e532e3f800b788b0248da86b1cd722e58e9c99413912fd029c20d88d55ebadc'`
+
+##### <a name="gpgkeyfingerprint"></a>`gpgkeyfingerprint`
+
+Data type: `Optional[String[40]]`
+
+
+
+Default value: ``undef``
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,14 +9,12 @@
 # @param manage_service Enable or disable the service management
 # @param manage_repo Enable or disable the repository setup
 # @param repourl String that completes the url for the upstream repository
-# @param gpgkeyfingerprint String with the ID from the gpg key that signed the packages
 # @param apt_key_hash the sha256 hashsum for the GPG key file that was used to sign the packages
 class lldpd (
   Enum['present', 'absent', 'latest'] $ensure            = 'present',
   Boolean                             $manage_repo       = false,
   Boolean                             $manage_service    = true,
   Optional[String[1]]                 $repourl           = undef,
-  Optional[String[40]]                $gpgkeyfingerprint = undef,
   String[1]                           $apt_key_hash      = '2e532e3f800b788b0248da86b1cd722e58e9c99413912fd029c20d88d55ebadc',
 ) {
   if $manage_repo {
@@ -31,9 +29,6 @@ class lldpd (
         }
       }
       'Debian': {
-        if ! $gpgkeyfingerprint {
-          fail('you must specify a `$gpgkeyfingerprint` when using `$manage_repo` on debian')
-        }
         # place the key in the keyrings directory where apt won't search for keys for all repos
         # ascii encoded files need to end with *.asc, binary files with .gpg...
         file { '/usr/share/keyrings/lldpd.asc':


### PR DESCRIPTION
The parameter isn't used anymore, so we should remove it.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
