### PR TITLE
drop legacy timer code

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,12 +72,4 @@ class lldpd (
       enable => true,
     }
   }
-  # TODO: remove this at some point...
-  # clean resources used by version < 3.0.0
-  file { ['/usr/local/bin/lldp2facts', '/etc/cron.d/lldp2facts']:
-    ensure => absent,
-  }
-  systemd::unit_file { ['lldp2facts.service', 'lldp2facts.timer']:
-    ensure => absent,
-  }
 }

--- a/spec/classes/lldpd_spec.rb
+++ b/spec/classes/lldpd_spec.rb
@@ -14,10 +14,6 @@ describe 'lldpd' do
         it { is_expected.to contain_class('lldpd') }
         it { is_expected.to contain_service('lldpd') }
         it { is_expected.to contain_package('lldpd') }
-        it { is_expected.to contain_systemd__unit_file('lldp2facts.service') }
-        it { is_expected.to contain_systemd__unit_file('lldp2facts.timer') }
-        it { is_expected.to contain_file('/etc/cron.d/lldp2facts').with_ensure('absent') }
-        it { is_expected.to contain_file('/usr/local/bin/lldp2facts').with_ensure('absent') }
 
         if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'].to_i < 27
           it { is_expected.to contain_yumrepo('lldpd') }


### PR DESCRIPTION
In the past we had a systemd timer that generated the fact as external
data. We set the resources to absent with the last major release. This
code can go no away since we will release 4.0.0 today.

---

This contains https://github.com/voxpupuli/puppet-lldpd/pull/132