### PR TITLE
puppetlabs-apt: update minimum version from 4.4.0 to 8.1.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 4.4.0 < 10.0.0"
+      "version_requirement": ">= 8.1.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
We make use of the keyring parameter from puppetlabs/apt which was not introduced until version 8.1.0

Fixes #139