### PR TITLE
Ensure yumrepo is always before package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@ class lldpd (
           baseurl  => "https://download.opensuse.org/repositories/home:/vbernat/${repourl}/",
           gpgcheck => 1,
         }
+        Yumrepo['lldpd'] -> Package['lldpd']
       }
       'Debian': {
         include apt # required so apt::key can access variables from init.pp


### PR DESCRIPTION
This isn't usually a problem, but it doesn't hurt to make it clear that there is a dependency.